### PR TITLE
ci(deps): security hardening of third-party GitHub Actions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0
 
       - name: Black Linter
         if: always()
-        uses: psf/black@stable
+        uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # 25.1.0
         with:
           options: "--check --verbose --diff"
           src: "./src"
@@ -33,7 +33,7 @@ jobs:
 
       - name: ISort Linter
         if: always()
-        uses: isort/isort-action@v1.1.1
+        uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326 # v1.1.1
 
       - name: Bandit Linter
         if: always()

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The action stores the retrieved secrets in output variables defined by the end u
 ## Example usage
 
 ```yaml
-uses: BeyondTrust/secrets-safe-action@v1
+uses: BeyondTrust/secrets-safe-action@9e2bbfd1aa4ae265a03d6a212c42e193551af485 # v1.0.0
 env:
   API_URL: ${{vars.API_URL}}
   VERIFY_CA: ${{vars.VERIFY_CA}}


### PR DESCRIPTION
This PR will pin github actions to a commit SHA. This will help defend against supply-chain attacks.

This PR is pre-approved by AppSec, and can be merged at your earliest opportunity.

If you have any questions or concerns, please reach out to appsecteam@beyondtrust.com.

Thank you for helping BeyondTrust stay secure!
