### PR TITLE
fix: harden GITHUB_OUTPUT writes against injection (BIPS-35830, BIPS-35845)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,5 +106,5 @@ Pre-commit hooks enforce Black, isort, Flake8, and Bandit — install with `pre-
 
 ## Key Dependencies
 
-- `beyondtrust-bips-library` — BeyondTrust SDK; raises typed exceptions (`CreationError`, `OptionsError`, etc.) that both `main.py` files catch explicitly
+- `beyondtrust-bips-library` — BeyondTrust SDK; `create_secret/src/main.py` catches typed SDK exceptions (`CreationError`, `OptionsError`, etc.) explicitly; `get_secret/src/main.py` uses a broad `except Exception` at the top level
 - `requests` — HTTP client; wrapped in a retry-enabled session

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,12 @@ Both actions support two mutually exclusive auth methods:
 1. **API Key** — `API_KEY` env var, optionally with `CERTIFICATE` + `CERTIFICATE_KEY`
 2. **OAuth Client Credentials** — `CLIENT_ID` + `CLIENT_SECRET` env vars
 
-`set_authentication()` in each `main.py` validates access (expects HTTP 200), configures certificates if provided, and sets API version (default 3.0, recommended 3.1).
+Both validate API access (expects HTTP 200), configure certificates if provided, and set API version (default 3.0, recommended 3.1).
 
 ### get_secret flow
-`main()` → `set_authentication()` → `get_secrets()` → sign out
+`main()` → (inline auth) → `get_secrets()` → sign out
 
-`get_secrets()` parses JSON input (up to 20 secrets), calls the bips library, masks each value via `::add-mask::`, and writes to `$GITHUB_OUTPUT` using UUID delimiters for multiline safety.
+Auth configuration is handled inline inside `main()` (no separate function). `get_secrets()` parses JSON input (up to 20 secrets), calls the bips library, masks each value via `::add-mask::`, and writes to `$GITHUB_OUTPUT` using UUID delimiters for multiline safety.
 
 ### create_secret flow
 `main()` → `set_authentication()` → `get_folder()` → `create_secret()` → sign out
@@ -91,7 +91,7 @@ Retry(total=3, backoff_factor=0.2, status_forcelist=[400, 408, 500, 502, 503, 50
 - **Line length:** 88 (Black default), enforced by both Black and Flake8
 - **Import order:** isort with Black profile
 - **Complexity:** max McCabe complexity 10 (`.flake8`)
-- **Coverage gate:** 80% minimum overall; 85% for new code (`.coveragerc`)
+- **Coverage gate:** 80% minimum overall; 85% for new code (enforced via `orgoro/coverage` in `.github/workflows/unit-tests.yml`)
 - **Security linting:** Bandit runs in CI and as a pre-commit hook
 
 Pre-commit hooks enforce Black, isort, Flake8, and Bandit — install with `pre-commit install`.
@@ -101,7 +101,7 @@ Pre-commit hooks enforce Black, isort, Flake8, and Bandit — install with `pre-
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
 | `linter.yml` | PR/push | Black, Flake8, isort, Bandit (all run even if one fails) |
-| `unit-tests.yml` | PR/push, tags `v*` | Runs both test suites, combines coverage, posts to PR via orgoro/coverage, uploads to SonarQube |
+| `unit-tests.yml` | PR/push, tags `v*` | Runs both test suites, combines coverage, posts coverage report to PR via orgoro/coverage |
 | `wiz.yml` | PR/push | WIZ cloud security scan |
 
 ## Key Dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A BeyondTrust GitHub Actions repository providing two Docker-based custom actions for integrating with BeyondTrust Secrets Safe:
+- **`get_secret/`** — Retrieves ASCII secrets and exposes them as masked GitHub Actions outputs
+- **`create_secret/`** — Creates new secrets (credential, text, or file types) in Secrets Safe
+
+Both actions are written in Python 3.11 on Alpine Linux containers and use the `beyondtrust-bips-library` SDK.
+
+## Commands
+
+### Install dependencies
+```bash
+pip install -r create_secret/requirements.txt -r create_secret/requirements-dev.txt
+pip install -r get_secret/requirements.txt -r get_secret/requirements-dev.txt
+```
+
+### Run tests
+```bash
+# Run tests for a single action (from repo root)
+cd create_secret && python3 -m coverage run --data-file=../.coverage.create -m unittest discover tests/unit -v -p 'test_*.py'
+cd get_secret && python3 -m coverage run --data-file=../.coverage.get -m unittest discover tests/unit -v -p 'test_*.py'
+
+# Combined coverage report
+python3 -m coverage combine .coverage.create .coverage.get && python3 -m coverage report
+```
+
+### Run linters (matches CI)
+```bash
+black --check create_secret/src get_secret/src
+isort --check-only create_secret/src get_secret/src
+flake8 create_secret/src get_secret/src
+bandit -r create_secret/src get_secret/src
+```
+
+### Local Docker testing
+```bash
+# Configure .env file in each action directory first
+docker-compose -f create_secret/docker-compose.yml up
+docker-compose -f get_secret/docker-compose.yml up
+```
+
+## Architecture
+
+### Code structure
+Each action is self-contained with identical layout:
+```
+<action>/
+├── action.yml          # GitHub Actions metadata (inputs/outputs/runs)
+├── Dockerfile          # python:3.11-alpine, non-root appuser (UID 1001)
+├── docker-compose.yml  # Local testing with .env file
+├── requirements.txt    # beyondtrust-bips-library>=2.0.0,<3.0.0, requests
+├── requirements-dev.txt
+└── src/main.py         # All logic lives here (~260-280 lines)
+    tests/unit/test_main.py
+```
+
+### Authentication flow (both actions)
+Both actions support two mutually exclusive auth methods:
+1. **API Key** — `API_KEY` env var, optionally with `CERTIFICATE` + `CERTIFICATE_KEY`
+2. **OAuth Client Credentials** — `CLIENT_ID` + `CLIENT_SECRET` env vars
+
+`set_authentication()` in each `main.py` validates access (expects HTTP 200), configures certificates if provided, and sets API version (default 3.0, recommended 3.1).
+
+### get_secret flow
+`main()` → `set_authentication()` → `get_secrets()` → sign out
+
+`get_secrets()` parses JSON input (up to 20 secrets), calls the bips library, masks each value via `::add-mask::`, and writes to `$GITHUB_OUTPUT` using UUID delimiters for multiline safety.
+
+### create_secret flow
+`main()` → `set_authentication()` → `get_folder()` → `create_secret()` → sign out
+
+`get_folder()` lists all folders and matches by exact name. `create_secret()` handles three secret types (CREDENTIAL, TEXT, FILE) and optionally creates a file attachment before creating the secret record.
+
+### HTTP session config (both actions)
+```python
+Retry(total=3, backoff_factor=0.2, status_forcelist=[400, 408, 500, 502, 503, 504])
+# Timeouts: connect=30s, read=30s
+```
+
+### Environment variable conventions
+- GitHub Actions inputs arrive as `INPUT_<NAME>` (uppercased)
+- Auth/config vars (`API_KEY`, `API_URL`, `CLIENT_ID`, etc.) have no prefix
+- `LOG_LEVEL` defaults to INFO; `VERIFY_CA` defaults to `true`
+
+## Code Quality
+
+- **Line length:** 88 (Black default), enforced by both Black and Flake8
+- **Import order:** isort with Black profile
+- **Complexity:** max McCabe complexity 10 (`.flake8`)
+- **Coverage gate:** 80% minimum overall; 85% for new code (`.coveragerc`)
+- **Security linting:** Bandit runs in CI and as a pre-commit hook
+
+Pre-commit hooks enforce Black, isort, Flake8, and Bandit — install with `pre-commit install`.
+
+## CI Workflows
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `linter.yml` | PR/push | Black, Flake8, isort, Bandit (all run even if one fails) |
+| `unit-tests.yml` | PR/push, tags `v*` | Runs both test suites, combines coverage, posts to PR via orgoro/coverage, uploads to SonarQube |
+| `wiz.yml` | PR/push | WIZ cloud security scan |
+
+## Key Dependencies
+
+- `beyondtrust-bips-library` — BeyondTrust SDK; raises typed exceptions (`CreationError`, `OptionsError`, etc.) that both `main.py` files catch explicitly
+- `requests` — HTTP client; wrapped in a retry-enabled session

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Both validate API access (expects HTTP 200), configure certificates if provided,
 ### get_secret flow
 `main()` → (inline auth) → `get_secrets()` → sign out
 
-Auth configuration is handled inline inside `main()` (no separate function). `get_secrets()` parses JSON input (up to 20 secrets), calls the bips library, masks each value via `::add-mask::`, and writes to `$GITHUB_OUTPUT` using UUID delimiters for multiline safety.
+Auth configuration is handled inline inside `main()` (no separate function). `get_secrets()` parses JSON input (up to 20 secrets), calls the bips library, masks each value via `::add-mask ::value` (space before second `::` is intentional — GitHub Actions accepts this form), and writes to `$GITHUB_OUTPUT` using UUID delimiters for multiline safety.
 
 ### create_secret flow
 `main()` → `set_authentication()` → `get_folder()` → `create_secret()` → sign out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Each action is self-contained with identical layout:
 ├── action.yml          # GitHub Actions metadata (inputs/outputs/runs)
 ├── Dockerfile          # python:3.11-alpine, non-root appuser (UID 1001)
 ├── docker-compose.yml  # Local testing with .env file
-├── requirements.txt    # beyondtrust-bips-library>=2.0.0,<3.0.0, requests
+├── requirements.txt    # beyondtrust-bips-library>=2.0.0,<3.0.0
 ├── requirements-dev.txt
 └── src/main.py         # All logic lives here (~260-280 lines)
     tests/unit/test_main.py

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="images/beyondtrust_logo.svg" alt="BeyondTrust" title="BeyondTrust" align="right" height="30">
 </a>
 
-# Beyondtrust Secrets Actions
+# BeyondTrust Secrets Actions
 
 This project integrates with BeyondTrust Password Safe and provides two core actions for secret management: get_secret and create_secret.
 The get_secret action is used to retrieve existing secrets, while the create_secret action allows the creation of new secrets.

--- a/create_secret/docker-compose.yml
+++ b/create_secret/docker-compose.yml
@@ -1,3 +1,4 @@
+# THIS FILE IS ONLY FOR TESTING/DEV PURPOSES. DO NOT USE THIS IN PRODUCTION.
 services:
   create_secret_action:
     build:

--- a/create_secret/requirements-dev.txt
+++ b/create_secret/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 coverage==7.3.1
 pre-commit==4.0.1
-pytest==9.0.2
+pytest==9.0.3

--- a/get_secret/docker-compose.yml
+++ b/get_secret/docker-compose.yml
@@ -1,3 +1,4 @@
+# THIS FILE IS ONLY FOR TESTING/DEV PURPOSES. DO NOT USE THIS IN PRODUCTION.
 services:
   get_secret_action:
     build:

--- a/get_secret/requirements-dev.txt
+++ b/get_secret/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 coverage==7.3.1
 pre-commit==4.0.1
-pytest==9.0.2
+pytest==9.0.3

--- a/get_secret/src/main.py
+++ b/get_secret/src/main.py
@@ -165,9 +165,9 @@ def get_secrets(
             r"[a-zA-Z_][a-zA-Z0-9_-]*", output_id
         ):
             common.show_error(
-                f"Invalid output_id {repr(output_id)}: must be a string starting with a "
-                "letter or underscore and contain only alphanumeric characters, "
-                "underscores, or hyphens",
+                f"Invalid output_id {repr(output_id)}: must be a string starting "
+                "with a letter or underscore and contain only alphanumeric "
+                "characters, underscores, or hyphens",
                 logger,
             )
 

--- a/get_secret/src/main.py
+++ b/get_secret/src/main.py
@@ -91,7 +91,7 @@ def mask_secret(command: str, secret_to_mask: str) -> None:
     lines = secret_to_mask.split("\n")
     for line in lines:
         if line.strip() != "":
-            full_command = f"{COMMAND_MARKER}{command} {COMMAND_MARKER}{line}"
+            full_command = f"{COMMAND_MARKER}{command}{COMMAND_MARKER}{line}"
             print(full_command)
 
 
@@ -165,7 +165,7 @@ def get_secrets(
             r"[a-zA-Z_][a-zA-Z0-9_-]*", output_id
         ):
             common.show_error(
-                f"Invalid output_id '{output_id}': must be a string starting with a "
+                f"Invalid output_id {repr(output_id)}: must be a string starting with a "
                 "letter or underscore and contain only alphanumeric characters, "
                 "underscores, or hyphens",
                 logger,

--- a/get_secret/src/main.py
+++ b/get_secret/src/main.py
@@ -161,8 +161,8 @@ def get_secrets(
             common.show_error("Invalid JSON, validate output_id attribute name", logger)
 
         output_id = secret_to_retrieve["output_id"]
-        if not isinstance(output_id, str) or not re.match(
-            r"^[a-zA-Z_][a-zA-Z0-9_-]*$", output_id
+        if not isinstance(output_id, str) or not re.fullmatch(
+            r"[a-zA-Z_][a-zA-Z0-9_-]*", output_id
         ):
             common.show_error(
                 f"Invalid output_id '{output_id}': must be a string starting with a "

--- a/get_secret/src/main.py
+++ b/get_secret/src/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import uuid
 
 import requests
@@ -68,7 +69,7 @@ def append_output(name: str, value: str) -> None:
     """
 
     with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
-        delimiter = uuid.uuid1()
+        delimiter = uuid.uuid4()
         print(f"{name}<<{delimiter}", file=fh)
         print(value, file=fh)
         print(delimiter, file=fh)
@@ -159,10 +160,20 @@ def get_secrets(
         if "output_id" not in secret_to_retrieve:
             common.show_error("Invalid JSON, validate output_id attribute name", logger)
 
+        output_id = secret_to_retrieve["output_id"]
+        if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_-]*$", output_id):
+            common.show_error(
+                f"Invalid output_id '{output_id}': must start with a letter or "
+                "underscore and contain only alphanumeric characters, underscores, "
+                "or hyphens",
+                logger,
+            )
+            continue
+
         get_secret_response = secret_obj.get_secret(secret_to_retrieve["path"])
         if get_secret_response:
             mask_secret("add-mask", get_secret_response)
-            append_output(secret_to_retrieve["output_id"], get_secret_response)
+            append_output(output_id, get_secret_response)
 
 
 def main() -> None:

--- a/get_secret/src/main.py
+++ b/get_secret/src/main.py
@@ -154,6 +154,11 @@ def get_secrets(
         )
 
     for secret_to_retrieve in secrets_to_retrive:
+        if not isinstance(secret_to_retrieve, dict):
+            common.show_error(
+                "Invalid JSON, each secret entry must be a JSON object", logger
+            )
+
         if "path" not in secret_to_retrieve:
             common.show_error("Invalid JSON, validate path attribute name", logger)
 

--- a/get_secret/src/main.py
+++ b/get_secret/src/main.py
@@ -161,14 +161,15 @@ def get_secrets(
             common.show_error("Invalid JSON, validate output_id attribute name", logger)
 
         output_id = secret_to_retrieve["output_id"]
-        if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_-]*$", output_id):
+        if not isinstance(output_id, str) or not re.match(
+            r"^[a-zA-Z_][a-zA-Z0-9_-]*$", output_id
+        ):
             common.show_error(
-                f"Invalid output_id '{output_id}': must start with a letter or "
-                "underscore and contain only alphanumeric characters, underscores, "
-                "or hyphens",
+                f"Invalid output_id '{output_id}': must be a string starting with a "
+                "letter or underscore and contain only alphanumeric characters, "
+                "underscores, or hyphens",
                 logger,
             )
-            continue
 
         get_secret_response = secret_obj.get_secret(secret_to_retrieve["path"])
         if get_secret_response:

--- a/get_secret/src/main.py
+++ b/get_secret/src/main.py
@@ -91,7 +91,7 @@ def mask_secret(command: str, secret_to_mask: str) -> None:
     lines = secret_to_mask.split("\n")
     for line in lines:
         if line.strip() != "":
-            full_command = f"{COMMAND_MARKER}{command}{COMMAND_MARKER}{line}"
+            full_command = f"{COMMAND_MARKER}{command} {COMMAND_MARKER}{line}"
             print(full_command)
 
 

--- a/get_secret/tests/unit/test_main.py
+++ b/get_secret/tests/unit/test_main.py
@@ -199,6 +199,7 @@ class TestMain(unittest.TestCase):
     @patch("src.main.append_output")
     def test_get_secrets_invalid_output_id_with_newline(self, mock_append, mock_show_error):
         """Test get_secrets rejects output_id containing a newline (injection attempt)"""
+        mock_show_error.side_effect = SystemExit(1)
         secret_obj = MagicMock()
         secret_obj.get_secret.return_value = "test_secret"
 
@@ -208,28 +209,52 @@ class TestMain(unittest.TestCase):
         }
         secrets_json = json.dumps(malicious_secret)
 
-        main.get_secrets(secret_obj, secrets_json)
+        with self.assertRaises(SystemExit):
+            main.get_secrets(secret_obj, secrets_json)
 
         mock_show_error.assert_called_once()
         args, _ = mock_show_error.call_args
         self.assertIn("Invalid output_id", args[0])
+        secret_obj.get_secret.assert_not_called()
         mock_append.assert_not_called()
 
     @patch("src.main.common.show_error")
     @patch("src.main.append_output")
     def test_get_secrets_invalid_output_id_special_chars(self, mock_append, mock_show_error):
         """Test get_secrets rejects output_id with disallowed special characters"""
+        mock_show_error.side_effect = SystemExit(1)
         secret_obj = MagicMock()
         secret_obj.get_secret.return_value = "test_secret"
 
         invalid_secret = {"path": "test_path", "output_id": "invalid id!"}
         secrets_json = json.dumps(invalid_secret)
 
-        main.get_secrets(secret_obj, secrets_json)
+        with self.assertRaises(SystemExit):
+            main.get_secrets(secret_obj, secrets_json)
 
         mock_show_error.assert_called_once()
         args, _ = mock_show_error.call_args
         self.assertIn("Invalid output_id", args[0])
+        secret_obj.get_secret.assert_not_called()
+        mock_append.assert_not_called()
+
+    @patch("src.main.common.show_error")
+    @patch("src.main.append_output")
+    def test_get_secrets_invalid_output_id_non_string(self, mock_append, mock_show_error):
+        """Test get_secrets rejects non-string output_id (e.g., null, number)"""
+        mock_show_error.side_effect = SystemExit(1)
+        secret_obj = MagicMock()
+
+        invalid_secret = {"path": "test_path", "output_id": None}
+        secrets_json = json.dumps(invalid_secret)
+
+        with self.assertRaises(SystemExit):
+            main.get_secrets(secret_obj, secrets_json)
+
+        mock_show_error.assert_called_once()
+        args, _ = mock_show_error.call_args
+        self.assertIn("Invalid output_id", args[0])
+        secret_obj.get_secret.assert_not_called()
         mock_append.assert_not_called()
 
     @patch("src.main.append_output")

--- a/get_secret/tests/unit/test_main.py
+++ b/get_secret/tests/unit/test_main.py
@@ -144,6 +144,22 @@ class TestMain(unittest.TestCase):
         )
 
     @patch("src.main.common.show_error")
+    def test_get_secrets_non_dict_entry(self, mock_show_error):
+        """Test get_secrets rejects list entries that are not dicts"""
+        mock_show_error.side_effect = SystemExit(1)
+
+        secret_obj = MagicMock()
+        secrets_json = json.dumps([123])
+
+        with self.assertRaises(SystemExit):
+            main.get_secrets(secret_obj, secrets_json)
+
+        mock_show_error.assert_called_once()
+        args, _ = mock_show_error.call_args
+        self.assertIn("each secret entry must be a JSON object", args[0])
+        secret_obj.get_secret.assert_not_called()
+
+    @patch("src.main.common.show_error")
     def test_get_secrets_max_secrets_exceeded(self, mock_show_error):
         """Test get_secrets with too many secrets"""
         # Mock show_error to raise SystemExit to simulate sys.exit(1)

--- a/get_secret/tests/unit/test_main.py
+++ b/get_secret/tests/unit/test_main.py
@@ -195,6 +195,43 @@ class TestMain(unittest.TestCase):
         args, _ = mock_show_error.call_args
         self.assertIn("validate output_id attribute name", args[0])
 
+    @patch("src.main.common.show_error")
+    @patch("src.main.append_output")
+    def test_get_secrets_invalid_output_id_with_newline(self, mock_append, mock_show_error):
+        """Test get_secrets rejects output_id containing a newline (injection attempt)"""
+        secret_obj = MagicMock()
+        secret_obj.get_secret.return_value = "test_secret"
+
+        malicious_secret = {
+            "path": "test_path",
+            "output_id": "valid_id\nINJECTED=value",  # noqa: S105 # nosec B105
+        }
+        secrets_json = json.dumps(malicious_secret)
+
+        main.get_secrets(secret_obj, secrets_json)
+
+        mock_show_error.assert_called_once()
+        args, _ = mock_show_error.call_args
+        self.assertIn("Invalid output_id", args[0])
+        mock_append.assert_not_called()
+
+    @patch("src.main.common.show_error")
+    @patch("src.main.append_output")
+    def test_get_secrets_invalid_output_id_special_chars(self, mock_append, mock_show_error):
+        """Test get_secrets rejects output_id with disallowed special characters"""
+        secret_obj = MagicMock()
+        secret_obj.get_secret.return_value = "test_secret"
+
+        invalid_secret = {"path": "test_path", "output_id": "invalid id!"}
+        secrets_json = json.dumps(invalid_secret)
+
+        main.get_secrets(secret_obj, secrets_json)
+
+        mock_show_error.assert_called_once()
+        args, _ = mock_show_error.call_args
+        self.assertIn("Invalid output_id", args[0])
+        mock_append.assert_not_called()
+
     @patch("src.main.append_output")
     @patch("src.main.mask_secret")
     def test_get_secrets_single_secret_as_dict(self, mock_mask, mock_append):

--- a/get_secret/tests/unit/test_main.py
+++ b/get_secret/tests/unit/test_main.py
@@ -80,7 +80,7 @@ class TestMain(unittest.TestCase):
     def test_mask_secret_single_line(self, mock_print):
         """Test mask_secret function with single line secret"""
         main.mask_secret("add-mask", "single_line_secret")
-        mock_print.assert_called_once_with("::add-mask ::single_line_secret")
+        mock_print.assert_called_once_with("::add-mask::single_line_secret")
 
     @patch("builtins.print")
     def test_mask_secret_multiple_lines(self, mock_print):
@@ -89,9 +89,9 @@ class TestMain(unittest.TestCase):
         main.mask_secret("add-mask", secret)
 
         expected_calls = [
-            call("::add-mask ::line1"),
-            call("::add-mask ::line2"),
-            call("::add-mask ::line3"),
+            call("::add-mask::line1"),
+            call("::add-mask::line2"),
+            call("::add-mask::line3"),
         ]
         mock_print.assert_has_calls(expected_calls)
 
@@ -102,7 +102,7 @@ class TestMain(unittest.TestCase):
         main.mask_secret("add-mask", secret)
 
         # Should only print non-empty lines
-        expected_calls = [call("::add-mask ::line1"), call("::add-mask ::line3")]
+        expected_calls = [call("::add-mask::line1"), call("::add-mask::line3")]
         mock_print.assert_has_calls(expected_calls)
 
     @patch("src.main.common.show_error")

--- a/get_secret/tests/unit/test_main.py
+++ b/get_secret/tests/unit/test_main.py
@@ -80,7 +80,7 @@ class TestMain(unittest.TestCase):
     def test_mask_secret_single_line(self, mock_print):
         """Test mask_secret function with single line secret"""
         main.mask_secret("add-mask", "single_line_secret")
-        mock_print.assert_called_once_with("::add-mask::single_line_secret")
+        mock_print.assert_called_once_with("::add-mask ::single_line_secret")
 
     @patch("builtins.print")
     def test_mask_secret_multiple_lines(self, mock_print):
@@ -89,9 +89,9 @@ class TestMain(unittest.TestCase):
         main.mask_secret("add-mask", secret)
 
         expected_calls = [
-            call("::add-mask::line1"),
-            call("::add-mask::line2"),
-            call("::add-mask::line3"),
+            call("::add-mask ::line1"),
+            call("::add-mask ::line2"),
+            call("::add-mask ::line3"),
         ]
         mock_print.assert_has_calls(expected_calls)
 
@@ -102,7 +102,7 @@ class TestMain(unittest.TestCase):
         main.mask_secret("add-mask", secret)
 
         # Should only print non-empty lines
-        expected_calls = [call("::add-mask::line1"), call("::add-mask::line3")]
+        expected_calls = [call("::add-mask ::line1"), call("::add-mask ::line3")]
         mock_print.assert_has_calls(expected_calls)
 
     @patch("src.main.common.show_error")

--- a/get_secret/tests/unit/test_main.py
+++ b/get_secret/tests/unit/test_main.py
@@ -220,6 +220,29 @@ class TestMain(unittest.TestCase):
 
     @patch("src.main.common.show_error")
     @patch("src.main.append_output")
+    def test_get_secrets_invalid_output_id_trailing_newline(self, mock_append, mock_show_error):
+        """Test get_secrets rejects output_id with a trailing newline (regex $ bypass)"""
+        mock_show_error.side_effect = SystemExit(1)
+        secret_obj = MagicMock()
+        secret_obj.get_secret.return_value = "test_secret"
+
+        trailing_newline_secret = {
+            "path": "test_path",
+            "output_id": "valid_id\n",  # noqa: S105 # nosec B105
+        }
+        secrets_json = json.dumps(trailing_newline_secret)
+
+        with self.assertRaises(SystemExit):
+            main.get_secrets(secret_obj, secrets_json)
+
+        mock_show_error.assert_called_once()
+        args, _ = mock_show_error.call_args
+        self.assertIn("Invalid output_id", args[0])
+        secret_obj.get_secret.assert_not_called()
+        mock_append.assert_not_called()
+
+    @patch("src.main.common.show_error")
+    @patch("src.main.append_output")
     def test_get_secrets_invalid_output_id_special_chars(self, mock_append, mock_show_error):
         """Test get_secrets rejects output_id with disallowed special characters"""
         mock_show_error.side_effect = SystemExit(1)


### PR DESCRIPTION
## Summary

- **BIPS-35830 (MEDIUM)** — Validate \`output_id\` against \`[a-zA-Z_][a-zA-Z0-9_-]*\` (via \`re.fullmatch\`) before writing to \`GITHUB_OUTPUT\`. Values that are non-strings, contain newlines (including trailing), or contain disallowed characters cause a fatal error, preventing heredoc injection that could plant arbitrary step output variables into downstream jobs.
- **BIPS-35845 (LOW)** — Replace \`uuid.uuid1()\` with \`uuid.uuid4()\` for the heredoc delimiter. UUID1 encodes MAC address + timestamp and is structurally predictable; UUID4 is cryptographically random, removing the theoretical path where a vault writer embeds a predicted delimiter in a secret value to break out of the heredoc.
- Unit tests added for all invalid \`output_id\` cases: embedded newline, trailing newline, special characters, and non-string values.

## Files changed

- \`get_secret/src/main.py\` — \`import re\` added; \`uuid.uuid1()\` → \`uuid.uuid4()\`; \`output_id\` validated with \`isinstance\` + \`re.fullmatch\` (fatal on violation)
- \`get_secret/tests/unit/test_main.py\` — 4 invalid \`output_id\` tests (embedded newline, trailing newline, special chars, non-string); all assert \`get_secret\` and \`append_output\` are never called
- \`CLAUDE.md\` — initial codebase guidance file for Claude Code
- \`README.md\` — fix capitalization typo (Beyondtrust → BeyondTrust)
- \`get_secret/requirements-dev.txt\`, \`create_secret/requirements-dev.txt\` — bump pytest 9.0.2 → 9.0.3 (Dependabot #8, #9)

## Test plan

- [x] All 18 unit tests pass
- [x] \`output_id\` containing embedded \`\n\` is rejected (fatal)
- [x] \`output_id\` with trailing \`\n\` is rejected (regex \`$\` bypass closed)
- [x] \`output_id\` with spaces/\`!\` is rejected (fatal)
- [x] Non-string \`output_id\` (null, number) is rejected without TypeError
- [x] Valid \`output_id\` values (\`title\`, \`my_secret\`, \`id-1\`) pass through normally
- [x] Linter checks pass (Black, Flake8, isort, Bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)