### PR TITLE
fix: BIPS-38269 bump bips-library minimum to 2.21.1 to fix secrets-by-path on API v3.2

### DIFF
--- a/create_secret/requirements.txt
+++ b/create_secret/requirements.txt
@@ -1,1 +1,1 @@
-beyondtrust-bips-library>=2.0.0,<3.0.0
+beyondtrust-bips-library>=2.21.1,<3.0.0

--- a/get_secret/requirements.txt
+++ b/get_secret/requirements.txt
@@ -1,1 +1,1 @@
-beyondtrust-bips-library>=2.0.0,<3.0.0
+beyondtrust-bips-library>=2.21.1,<3.0.0


### PR DESCRIPTION
> This PR was generated by Claude Code on 2026-05-29 on behalf of Felipe Hernandez.

## Purpose of the PR

- Fix secrets-by-path retrieval failure on BeyondTrust API version 3.2 caused by a changed response shape (BIPS-38269)

## Linked JIRA issue(s)

- [BIPS-38269](https://beyondtrust.atlassian.net/browse/BIPS-38269)

## Summary of changes

API version 3.2 introduced a changed response shape for the secrets-by-path endpoint. The `beyondtrust-bips-library` SDK fixed this in v2.21.1. Both action requirement files are updated to enforce the minimum library version that includes the fix:

- `create_secret/requirements.txt`: `beyondtrust-bips-library>=2.0.0,<3.0.0` → `>=2.21.1,<3.0.0`
- `get_secret/requirements.txt`: `beyondtrust-bips-library>=2.0.0,<3.0.0` → `>=2.21.1,<3.0.0`

The upper bound (`<3.0.0`) is preserved to avoid pulling in any future breaking major-version changes.

## Checklist

### Release

- [ ] Priority release required due to hotfix / Escalation / Critical bug
- [ ] Priority release not required (can be released later with other stories or bug fixes)

### Testing

- [ ] dev <!-- include description of the dev testing that was done -->
- [ ] automation (required for feature branch merges and significant changes) <!-- link to automation results and integration build/deployment if this is a feature branch merge to main or other significant change -->
- [ ] manual (required for feature branch merges and significant changes) <!-- link to verification results and integration build/deployment if this is a feature branch merge to main or other significant change -->

### Automation

- [ ] no changes are required
- [ ] existing tests have been updated
- [ ] new tests have been added
- [ ] further changes are required by the automation team

[BIPS-38269]: https://beyondtrust.atlassian.net/browse/BIPS-38269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ