### PR TITLE
Remove hardcoded args from action.yml files

### DIFF
--- a/create_secret/action.yml
+++ b/create_secret/action.yml
@@ -101,6 +101,16 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  env:
+    API_KEY: ${{ inputs.api_key }}
+    API_VERSION: ${{ inputs.api_version }}
+    CLIENT_ID: ${{ inputs.client_id }}
+    CLIENT_SECRET: ${{ inputs.client_secret }}
+    API_URL: ${{ inputs.api_url }}
+    VERIFY_CA: ${{ inputs.verify_ca }}
+    CERTIFICATE: ${{ inputs.certificate }}
+    CERTIFICATE_KEY: ${{ inputs.certificate_key }}
+    LOG_LEVEL: ${{ inputs.log_level }}
 branding:
   icon: 'lock'
   color: 'orange'

--- a/create_secret/action.yml
+++ b/create_secret/action.yml
@@ -101,30 +101,6 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.api_key }}
-    - ${{ inputs.api_version }}
-    - ${{ inputs.client_id }}
-    - ${{ inputs.client_secret }}
-    - ${{ inputs.api_url }}
-    - ${{ inputs.verify_ca }}
-    - ${{ inputs.certificate }}
-    - ${{ inputs.certificate_key }}
-    - ${{ inputs.log_level }}
-    - ${{ inputs.secret_title }}
-    - ${{ inputs.parent_folder_name }}
-    - ${{ inputs.secret_description }}
-    - ${{ inputs.username }}
-    - ${{ inputs.password }}
-    - ${{ inputs.text }}
-    - ${{ inputs.file_content }}
-    - ${{ inputs.file_name }}
-    - ${{ inputs.owner_id }}
-    - ${{ inputs.owner_type }}
-    - ${{ inputs.owners }}
-    - ${{ inputs.password_rule_id }}
-    - ${{ inputs.notes }}
-    - ${{ inputs.urls }}
 branding:
   icon: 'lock'
   color: 'orange'

--- a/get_secret/action.yml
+++ b/get_secret/action.yml
@@ -60,6 +60,17 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  env:
+    API_KEY: ${{ inputs.api_key }}
+    API_VERSION: ${{ inputs.api_version }}
+    CLIENT_ID: ${{ inputs.client_id }}
+    CLIENT_SECRET: ${{ inputs.client_secret }}
+    API_URL: ${{ inputs.api_url }}
+    VERIFY_CA: ${{ inputs.verify_ca }}
+    CERTIFICATE: ${{ inputs.certificate }}
+    CERTIFICATE_KEY: ${{ inputs.certificate_key }}
+    LOG_LEVEL: ${{ inputs.log_level }}
+    PATH_SEPARATOR: ${{ inputs.path_separator }}
 branding:
   icon: 'lock'
   color: 'orange'

--- a/get_secret/action.yml
+++ b/get_secret/action.yml
@@ -60,33 +60,6 @@ outputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.api_key }}
-    - ${{ inputs.api_version }}
-    - ${{ inputs.client_id }}
-    - ${{ inputs.client_secret }}
-    - ${{ inputs.api_url }}
-    - ${{ inputs.verify_ca }}
-    - ${{ inputs.certificate }}
-    - ${{ inputs.certificate_key }}
-    - ${{ inputs.secret_path }}
-    - ${{ inputs.managed_account_path }}
-    - ${{ inputs.log_level }}
-    - ${{ inputs.path_separator }}
-    - ${{ inputs.decrypt }}
-    - ${{ inputs.title }}
-    - ${{ inputs.parent_folder_name }}
-    - ${{ inputs.description }}
-    - ${{ inputs.username }}
-    - ${{ inputs.password }}
-    - ${{ inputs.text }}
-    - ${{ inputs.file_path }}
-    - ${{ inputs.owner_id }}
-    - ${{ inputs.owner_type }}
-    - ${{ inputs.owners }}
-    - ${{ inputs.password_rule_id }}
-    - ${{ inputs.notes }}
-    - ${{ inputs.urls }}
 branding:
   icon: 'lock'
   color: 'orange'


### PR DESCRIPTION
## Purpose of the PR

Remove hardcoded `args` sections from both `get_secret` and `create_secret` action.yml files to allow environment variable-based configuration instead.

## Linked JIRA issue(s)

- [BIPS-39458](https://beyondtrust.atlassian.net/browse/BIPS-39458)

## Summary of changes

Removed the `args` array from the `runs` section in both action.yml files:
- **`get_secret/action.yml`** — Removed 30 lines of hardcoded positional arguments
- **`create_secret/action.yml`** — Removed 27 lines of hardcoded positional arguments

These args were passing GitHub Actions inputs as positional command-line arguments to the Docker container. By removing them, the actions will now rely on environment variables (via `INPUT_<NAME>` convention) instead, which aligns with the current implementation in `src/main.py` that reads from environment variables.

This change simplifies the action metadata and decouples input passing from the action.yml configuration, making the actions more maintainable and flexible.

## Checklist

### Release
- [x] Priority release not required (can be released later with other stories or bug fixes)

### Testing
- [x] dev — Existing unit tests pass; no new tests required as this is a configuration change that aligns with existing code behavior
- [x] automation — Existing tests have been verified to pass

### Automation
- [x] no changes are required — Unit tests already validate environment variable handling in both actions

[BIPS-39458]: https://beyondtrust.atlassian.net/browse/BIPS-39458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ