### PR TITLE
feat: BIPS-34603 support CA bundle path in VERIFY_CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Values are case-insensitive and surrounding whitespace is ignored. Anything else
 These are Docker container actions, so the bundle must exist **inside the action container**, which does not inherit the runner's trust store. The runner mounts the repository workspace at `/github/workspace` in the container, so a bundle that is checked in — or written by an earlier step — is reachable under that path:
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
 - name: Get secret
   uses: BeyondTrust/secrets-safe-action/get_secret@bd174328f6b88a6cd795049a9dbe2a81c8669342 # v2.0.0

--- a/README.md
+++ b/README.md
@@ -105,11 +105,13 @@ Certificate private key (key.pem). For use when authenticating with an API key
 
 ### `verify_ca`
 
-Indicates whether to verify the certificate authority on the Secrets Safe instance. Defaults to true if not specified.
+Indicates whether to verify the certificate authority on the Secrets Safe instance. Defaults to true if not specified. Accepts `true`, `false`, or the path to a CA bundle inside the action container.
 ```
 VERIFY_CA: true
 ```
 Warning: false is insecure, instructs the Secrets Safe custom action not to verify the certificate authority.
+
+`true` verifies against `certifi`'s bundled roots, **not** the operating system trust store, so a private or internal CA has to be supplied as a bundle path. See [TLS certificate verification (`VERIFY_CA`)](#tls-certificate-verification-verify_ca).
 
 ### `log_level`
 Level of logging verbosity. Default INFO.
@@ -182,7 +184,7 @@ https://example.com:443/BeyondTrust/api/public/v3
 **Optional:** The recommended version is 3.1. If no version is specified, the default API version 3.0 will be used.
 
 #### `verify_ca`
-**Optional:** Indicates whether to verify the certificate authority on the Secrets Safe instance. Defaults to `true`.
+**Optional:** Indicates whether to verify the certificate authority on the Secrets Safe instance. Defaults to `true`. Accepts `true`, `false`, or the path to a CA bundle inside the action container — `true` verifies against `certifi`'s bundled roots, **not** the operating system trust store. See [TLS certificate verification (`VERIFY_CA`)](#tls-certificate-verification-verify_ca).
 
 #### `certificate`
 **Optional:** Content of the certificate (cert.pem) for use when authenticating with an API key using a Client Certificate.
@@ -338,6 +340,58 @@ Levels: `CRITICAL`, `FATAL`, `ERROR`, `WARNING`, `WARN`, `INFO`, `DEBUG`, `NOTSE
     OWNER_TYPE: "User"
     NOTES: ""
     OWNERS: '[{"owner_id": 1}]'
+```
+
+## TLS certificate verification (`VERIFY_CA`)
+
+Both actions read the same `VERIFY_CA` environment variable, which accepts three kinds of value:
+
+| Value | Behavior |
+| --- | --- |
+| `true` (default), `1`, `yes`, `on`, `enable`, `enabled` | Verify against the CA store the `requests` library defaults to — the roots bundled with `certifi`. |
+| `false`, `0`, `no`, `off`, `disable`, `disabled` | **Insecure.** Skip certificate verification entirely. |
+| A path to an existing file or directory, e.g. `/github/workspace/ca/ca-bundle.crt` | Verify against that CA bundle. |
+
+Values are case-insensitive and surrounding whitespace is ignored. Anything else — including a mistyped or missing bundle path — fails the step at startup with an `EnvironmentError` rather than silently falling back to `true` and failing to trust the CA you asked for.
+
+**`true` is not the operating system trust store.** `requests` verifies against `certifi`'s bundled Mozilla root certificates, not OpenSSL's default paths, so `true` and `/etc/pki/tls/certs/ca-bundle.crt` are *different* trust stores and can behave differently. Anything an administrator added to a host's OS store with `update-ca-trust` / `update-ca-certificates` — an internal PKI or a self-signed Password Safe certificate — is invisible to `certifi`. If Password Safe presents a certificate that does not chain to a public root, `VERIFY_CA: "true"` fails with `CERTIFICATE_VERIFY_FAILED` and you must point `VERIFY_CA` at a bundle that contains your CA. Do not disable verification to work around this.
+
+### Supplying a CA bundle
+
+These are Docker container actions, so the bundle must exist **inside the action container**, which does not inherit the runner's trust store. The runner mounts the repository workspace at `/github/workspace` in the container, so a bundle that is checked in — or written by an earlier step — is reachable under that path:
+
+```yaml
+- uses: actions/checkout@v4
+
+- name: Get secret
+  uses: BeyondTrust/secrets-safe-action/get_secret@bd174328f6b88a6cd795049a9dbe2a81c8669342 # v2.0.0
+  env:
+    API_URL: ${{vars.API_URL}}
+    CLIENT_ID: ${{secrets.CLIENT_ID}}
+    CLIENT_SECRET: ${{secrets.CLIENT_SECRET}}
+    # Path inside the container, not on the runner.
+    VERIFY_CA: "/github/workspace/ca/ca-bundle.crt"
+  with:
+    SECRET_PATH: '{"path": "folder1/folder2/title", "output_id": "title"}'
+```
+
+To keep the bundle out of the repository, write it from a secret in a preceding step:
+
+```yaml
+- name: Write CA bundle
+  run: |
+    mkdir -p "$GITHUB_WORKSPACE/ca"
+    printf '%s\n' "${{ secrets.CA_BUNDLE }}" > "$GITHUB_WORKSPACE/ca/ca-bundle.crt"
+```
+
+Use the literal `/github/workspace/...` path for `VERIFY_CA`: `${{ github.workspace }}` expands to the path on the runner (for example `/home/runner/work/repo/repo`), which does not exist inside the container.
+
+As an alternative that needs no change to `VERIFY_CA`, `requests` also honors the standard `REQUESTS_CA_BUNDLE` (or `CURL_CA_BUNDLE`) environment variable whenever verification is enabled; set it on the step's `env` with the same in-container path. Note that `SSL_CERT_FILE` has no effect on `requests`.
+
+The action logs which trust store is in effect at `INFO` level, which is the quickest way to confirm the bundle was picked up:
+
+```
+Verifying certificates against CA bundle: /github/workspace/ca/ca-bundle.crt
 ```
 
 ## Extracting Client Secret

--- a/create_secret/action.yml
+++ b/create_secret/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: true
     default: ''
   verify_ca:
-    description: 'Indicates whether to verify the certificate authority on the Secrets Safe instance. For use when authenticating to Secrets Safe.'
+    description: 'Indicates whether to verify the certificate authority on the Secrets Safe instance. Accepts true, false, or the path to a CA bundle inside the action container (the workspace is mounted at /github/workspace). true verifies against certifi bundled roots, not the OS trust store. For use when authenticating to Secrets Safe.'
     required: false
     default: 'true'
   certificate:

--- a/create_secret/src/main.py
+++ b/create_secret/src/main.py
@@ -12,7 +12,7 @@ This module is responsible for:
 import json
 import logging
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import requests
 import secrets_safe_library
@@ -35,7 +35,7 @@ CLIENT_ID = env.get("CLIENT_ID")
 CLIENT_SECRET = env.get("CLIENT_SECRET")
 API_URL = env.get("API_URL")
 API_VERSION = env.get("API_VERSION")
-VERIFY_CA = env.get("VERIFY_CA", "true").lower() != "false"
+# VERIFY_CA is resolved below, once the logger exists to report a bad value.
 TIMEOUT_CONNECTION_SECONDS = 30
 TIMEOUT_REQUEST_SECONDS = 30
 CERTIFICATE = env.get("CERTIFICATE", "").replace(r"\n", "\n")
@@ -78,6 +78,121 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(LOGGER_NAME)
+
+# Tokens that explicitly enable / disable TLS certificate verification.
+VERIFY_CA_TRUE_TOKENS = frozenset({"true", "1", "yes", "on", "enable", "enabled"})
+VERIFY_CA_FALSE_TOKENS = frozenset({"false", "0", "no", "off", "disable", "disabled"})
+
+
+def parse_verify_ca(value: Union[str, None]) -> Union[bool, str]:
+    """
+    Parse the VERIFY_CA environment variable.
+
+    Fails closed: verification is only disabled for an explicitly recognized
+    false token (false/0/no/off/disable/disabled, case-insensitive). A value
+    that points to an existing file or directory is passed through as a CA
+    bundle path, and anything unrecognized raises rather than silently ignoring
+    the caller's intent.
+
+    Note that True verifies against the CA store the requests library defaults
+    to (certifi's bundled roots), which is *not* the operating system trust
+    store. To trust a private/internal CA, pass the bundle path here - the
+    bundle must exist inside the action container, where the workspace is
+    mounted at /github/workspace.
+
+    Args:
+        value (str | None): Raw VERIFY_CA value, None when unset.
+
+    Returns:
+        bool | str: True to verify against the default CA store, False to
+        disable verification, or a path to a CA bundle file/directory.
+
+    Raises:
+        EnvironmentError: If the value is neither a recognized token nor an
+        existing path.
+    """
+
+    if value is None:
+        return True
+
+    normalized = value.strip()
+
+    if not normalized:
+        return True
+
+    token = normalized.lower()
+
+    if token in VERIFY_CA_TRUE_TOKENS:
+        return True
+
+    if token in VERIFY_CA_FALSE_TOKENS:
+        return False
+
+    # Allow pinning a custom CA bundle file or directory by path.
+    if os.path.exists(normalized):
+        return normalized
+
+    raise EnvironmentError(
+        f"Invalid value for VERIFY_CA: {value!r}. Use 'true'/'false' or a path "
+        "to an existing CA bundle inside the action container (the repository "
+        "workspace is mounted at /github/workspace). Refusing to continue "
+        "rather than silently ignoring the requested CA bundle."
+    )
+
+
+def configure_certificate_verification(
+    session: requests.Session, verify_ca: Union[bool, str]
+) -> None:
+    """
+    Apply the CA verification setting to the session and log the trust store
+    that is actually in effect.
+
+    The bundle path is assigned here so the session is correct on its own,
+    independent of the Authentication object also assigning it.
+
+    Args:
+        session (requests.Session): Session used for every API call.
+        verify_ca (bool | str): True to verify against the CA store requests
+            defaults to (certifi's bundled roots, *not* the operating system
+            trust store), False to disable verification, or a path to a CA
+            bundle file/directory to verify against instead.
+    """
+
+    session.verify = verify_ca
+
+    if verify_ca is False:
+        # The library already warns that disabling verification is insecure.
+        return
+
+    if isinstance(verify_ca, str):
+        utils.print_log(
+            logger,
+            f"Verifying certificates against CA bundle: {verify_ca}",
+            logging.INFO,
+        )
+        return
+
+    # requests swaps in REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE at request time when
+    # verify is True, so report the store that is actually in effect.
+    ca_store = f"certifi: {requests.adapters.DEFAULT_CA_BUNDLE_PATH}"
+    for env_var in ("REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        if env.get(env_var):
+            ca_store = f"overridden by {env_var}: {env[env_var]}"
+            break
+
+    utils.print_log(
+        logger,
+        "Verifying certificates against the CA store used by requests "
+        f"({ca_store}). Set VERIFY_CA to a CA bundle path to trust a private "
+        "CA instead.",
+        logging.INFO,
+    )
+
+
+try:
+    VERIFY_CA = parse_verify_ca(env.get("VERIFY_CA"))
+except EnvironmentError as verify_ca_error:
+    common.show_error(str(verify_ca_error), logger)
 
 
 def get_folder(
@@ -206,6 +321,8 @@ def set_authentication(
     Returns:
         authentication.Authentication: Authenticated Secrets Safe client.
     """
+
+    configure_certificate_verification(session, VERIFY_CA)
 
     certificate, certificate_key = utils.prepare_certificate_info(
         CERTIFICATE, CERTIFICATE_KEY

--- a/create_secret/tests/unit/test_main.py
+++ b/create_secret/tests/unit/test_main.py
@@ -1,8 +1,18 @@
+import os
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
+import requests
 from secrets_safe_library.exceptions import CreationError, OptionsError
-from src.main import create_secret, get_folder, main, set_authentication
+from src.main import (
+    configure_certificate_verification,
+    create_secret,
+    get_folder,
+    main,
+    parse_verify_ca,
+    set_authentication,
+)
 
 
 class TestMain(unittest.TestCase):
@@ -245,6 +255,143 @@ class TestMain(unittest.TestCase):
             create_secret(mock_auth)
 
         mock_show_error.assert_called_once()
+
+
+class TestParseVerifyCA(unittest.TestCase):
+    """
+    Tests for parse_verify_ca, which accepts a CA bundle path so a private or
+    internal CA can be trusted without disabling verification.
+    """
+
+    def test_true_when_unset(self):
+        """An unset VERIFY_CA keeps verification enabled."""
+        self.assertIs(parse_verify_ca(None), True)
+
+    def test_true_when_empty_or_whitespace(self):
+        """An empty or whitespace-only value keeps verification enabled."""
+        for value in ("", "   "):
+            with self.subTest(value=value):
+                self.assertIs(parse_verify_ca(value), True)
+
+    def test_all_enable_tokens_are_recognized(self):
+        """Every affirmative token enables verification."""
+        for token in ("true", "1", "yes", "on", "enable", "enabled", " TRUE "):
+            with self.subTest(token=token):
+                self.assertIs(parse_verify_ca(token), True)
+
+    def test_all_disable_tokens_are_recognized(self):
+        """Every negative token disables verification."""
+        for token in ("false", "0", "no", "off", "disable", "disabled", " FALSE "):
+            with self.subTest(token=token):
+                self.assertIs(parse_verify_ca(token), False)
+
+    def test_existing_bundle_file_is_passed_through(self):
+        """A path to an existing bundle file is returned as-is."""
+        with tempfile.NamedTemporaryFile(suffix=".crt") as bundle:
+            self.assertEqual(parse_verify_ca(bundle.name), bundle.name)
+
+    def test_existing_bundle_directory_is_passed_through(self):
+        """A path to an existing bundle directory is returned as-is."""
+        with tempfile.TemporaryDirectory() as bundle_dir:
+            self.assertEqual(parse_verify_ca(bundle_dir), bundle_dir)
+
+    def test_bundle_path_is_stripped(self):
+        """Surrounding whitespace is trimmed from a bundle path."""
+        with tempfile.NamedTemporaryFile(suffix=".crt") as bundle:
+            self.assertEqual(parse_verify_ca(f"  {bundle.name}  "), bundle.name)
+
+    def test_nonexistent_path_raises(self):
+        """
+        Fail closed: a mistyped bundle path must not silently fall back to
+        certifi, which would not trust the CA the caller asked for.
+        """
+        with self.assertRaises(EnvironmentError) as ctx:
+            parse_verify_ca("/no/such/ca-bundle.crt")
+
+        self.assertIn("VERIFY_CA", str(ctx.exception))
+
+    def test_unrecognized_value_raises(self):
+        """An unrecognized value is rejected instead of defaulting to True."""
+        with self.assertRaises(EnvironmentError):
+            parse_verify_ca("maybe")
+
+
+class TestConfigureCertificateVerification(unittest.TestCase):
+    """
+    Tests for configure_certificate_verification, which applies the setting to
+    the session and reports the trust store actually in effect.
+    """
+
+    def _verify_true_log_message(self, env_overrides):
+        """Return the message logged for verify_ca=True under env_overrides."""
+        session = requests.Session()
+        with patch.dict(os.environ, env_overrides, clear=True):
+            with patch("src.main.utils.print_log") as print_log:
+                configure_certificate_verification(session, True)
+        return print_log.call_args[0][1]
+
+    def test_session_verifies_against_bundle_path(self):
+        """A bundle path is assigned to the session itself."""
+        session = requests.Session()
+        with tempfile.NamedTemporaryFile(suffix=".crt") as bundle:
+            configure_certificate_verification(session, bundle.name)
+            self.assertEqual(session.verify, bundle.name)
+
+    def test_session_verify_defaults_to_true(self):
+        """verify_ca=True leaves the session verifying against the default store."""
+        session = requests.Session()
+        configure_certificate_verification(session, True)
+        self.assertIs(session.verify, True)
+
+    def test_session_verify_disabled(self):
+        """verify_ca=False disables verification on the session."""
+        session = requests.Session()
+        configure_certificate_verification(session, False)
+        self.assertFalse(session.verify)
+
+    def test_log_names_bundle_path(self):
+        """The bundle path in effect is logged."""
+        session = requests.Session()
+        with tempfile.NamedTemporaryFile(suffix=".crt") as bundle:
+            with patch("src.main.utils.print_log") as print_log:
+                configure_certificate_verification(session, bundle.name)
+
+            self.assertIn(bundle.name, print_log.call_args[0][1])
+
+    def test_log_names_requests_ca_bundle_override(self):
+        """
+        requests silently honors REQUESTS_CA_BUNDLE when verify is True, so the
+        log must name it instead of claiming certifi is in effect.
+        """
+        message = self._verify_true_log_message({"REQUESTS_CA_BUNDLE": "/tmp/req.crt"})
+
+        self.assertIn("REQUESTS_CA_BUNDLE", message)
+        self.assertIn("/tmp/req.crt", message)
+        self.assertNotIn(requests.adapters.DEFAULT_CA_BUNDLE_PATH, message)
+
+    def test_log_names_curl_ca_bundle_override(self):
+        """CURL_CA_BUNDLE is honored by requests too, so it is reported."""
+        message = self._verify_true_log_message({"CURL_CA_BUNDLE": "/tmp/curl.crt"})
+
+        self.assertIn("CURL_CA_BUNDLE", message)
+        self.assertIn("/tmp/curl.crt", message)
+
+    def test_requests_ca_bundle_takes_precedence_over_curl(self):
+        """REQUESTS_CA_BUNDLE wins when both overrides are set."""
+        message = self._verify_true_log_message(
+            {"REQUESTS_CA_BUNDLE": "/tmp/req.crt", "CURL_CA_BUNDLE": "/tmp/curl.crt"}
+        )
+
+        self.assertIn("/tmp/req.crt", message)
+        self.assertNotIn("/tmp/curl.crt", message)
+
+    def test_log_reports_certifi_when_no_override(self):
+        """Without an override the certifi bundle path is reported."""
+        message = self._verify_true_log_message({})
+
+        self.assertIn("certifi", message)
+        self.assertIn(requests.adapters.DEFAULT_CA_BUNDLE_PATH, message)
+        self.assertIn("VERIFY_CA", message)
 
 
 if __name__ == "__main__":

--- a/get_secret/action.yml
+++ b/get_secret/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: true
     default: ''
   verify_ca:
-    description: 'Indicates whether to verify the certificate authority on the Secrets Safe instance. For use when authenticating to Secrets Safe.'
+    description: 'Indicates whether to verify the certificate authority on the Secrets Safe instance. Accepts true, false, or the path to a CA bundle inside the action container (the workspace is mounted at /github/workspace). true verifies against certifi bundled roots, not the OS trust store. For use when authenticating to Secrets Safe.'
     required: false
     default: 'true'
   certificate:

--- a/get_secret/src/main.py
+++ b/get_secret/src/main.py
@@ -18,7 +18,7 @@ CLIENT_ID = env.get("CLIENT_ID")
 CLIENT_SECRET = env.get("CLIENT_SECRET")
 API_URL = env.get("API_URL")
 API_VERSION = env.get("API_VERSION")
-VERIFY_CA = env.get("VERIFY_CA", "true").lower() != "false"
+# VERIFY_CA is resolved below, once the logger exists to report a bad value.
 DECRYPT = env.get("INPUT_DECRYPT", "true").lower() == "true"
 
 SECRET_PATH = env.get("INPUT_SECRET_PATH", "").strip() or None
@@ -54,6 +54,124 @@ CERTIFICATE = env.get("CERTIFICATE", "").replace(r"\n", "\n")
 CERTIFICATE_KEY = env.get("CERTIFICATE_KEY", "").replace(r"\n", "\n")
 
 COMMAND_MARKER: str = "::"
+
+# Tokens that explicitly enable / disable TLS certificate verification.
+VERIFY_CA_TRUE_TOKENS = frozenset({"true", "1", "yes", "on", "enable", "enabled"})
+VERIFY_CA_FALSE_TOKENS = frozenset({"false", "0", "no", "off", "disable", "disabled"})
+
+
+def parse_verify_ca(value: str | None) -> bool | str:
+    """
+    Parse the VERIFY_CA environment variable.
+
+    Fails closed: verification is only disabled for an explicitly recognized
+    false token (false/0/no/off/disable/disabled, case-insensitive). A value
+    that points to an existing file or directory is passed through as a CA
+    bundle path, and anything unrecognized raises rather than silently ignoring
+    the caller's intent.
+
+    Note that True verifies against the CA store the requests library defaults
+    to (certifi's bundled roots), which is *not* the operating system trust
+    store. To trust a private/internal CA, pass the bundle path here - the
+    bundle must exist inside the action container, where the workspace is
+    mounted at /github/workspace.
+
+    Arguments:
+        value (str | None): Raw VERIFY_CA value, None when unset.
+
+    Returns:
+        bool | str: True to verify against the default CA store, False to
+        disable verification, or a path to a CA bundle file/directory.
+
+    Raises:
+        EnvironmentError: If the value is neither a recognized token nor an
+        existing path.
+    """
+
+    if value is None:
+        return True
+
+    normalized = value.strip()
+
+    if not normalized:
+        return True
+
+    token = normalized.lower()
+
+    if token in VERIFY_CA_TRUE_TOKENS:
+        return True
+
+    if token in VERIFY_CA_FALSE_TOKENS:
+        return False
+
+    # Allow pinning a custom CA bundle file or directory by path.
+    if os.path.exists(normalized):
+        return normalized
+
+    raise EnvironmentError(
+        f"Invalid value for VERIFY_CA: {value!r}. Use 'true'/'false' or a path "
+        "to an existing CA bundle inside the action container (the repository "
+        "workspace is mounted at /github/workspace). Refusing to continue "
+        "rather than silently ignoring the requested CA bundle."
+    )
+
+
+def configure_certificate_verification(
+    session: requests.Session, verify_ca: bool | str
+) -> None:
+    """
+    Applies the CA verification setting to the session and logs the trust store
+    that is actually in effect.
+
+    The bundle path is assigned here so the session is correct on its own,
+    independent of the Authentication object also assigning it.
+
+    Arguments:
+        session (requests.Session): Session used for every API call.
+        verify_ca (bool | str): True to verify against the CA store requests
+            defaults to (certifi's bundled roots, *not* the operating system
+            trust store), False to disable verification, or a path to a CA
+            bundle file/directory to verify against instead.
+
+    Returns:
+        None
+    """
+
+    session.verify = verify_ca
+
+    if verify_ca is False:
+        # The library already warns that disabling verification is insecure.
+        return
+
+    if isinstance(verify_ca, str):
+        utils.print_log(
+            logger,
+            f"Verifying certificates against CA bundle: {verify_ca}",
+            logging.INFO,
+        )
+        return
+
+    # requests swaps in REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE at request time when
+    # verify is True, so report the store that is actually in effect.
+    ca_store = f"certifi: {requests.adapters.DEFAULT_CA_BUNDLE_PATH}"
+    for env_var in ("REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        if env.get(env_var):
+            ca_store = f"overridden by {env_var}: {env[env_var]}"
+            break
+
+    utils.print_log(
+        logger,
+        "Verifying certificates against the CA store used by requests "
+        f"({ca_store}). Set VERIFY_CA to a CA bundle path to trust a private "
+        "CA instead.",
+        logging.INFO,
+    )
+
+
+try:
+    VERIFY_CA = parse_verify_ca(env.get("VERIFY_CA"))
+except EnvironmentError as verify_ca_error:
+    common.show_error(str(verify_ca_error), logger)
 
 
 def append_output(name: str, value: str) -> None:
@@ -222,6 +340,8 @@ def main() -> None:
             adapter = HTTPAdapter(max_retries=retry_strategy)
             session.mount("https://", adapter)
             session.mount("http://", adapter)
+
+            configure_certificate_verification(session, VERIFY_CA)
 
             certificate, certificate_key = utils.prepare_certificate_info(
                 CERTIFICATE, CERTIFICATE_KEY

--- a/get_secret/tests/unit/test_main.py
+++ b/get_secret/tests/unit/test_main.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, call, patch
 
+import requests
 from src import main
 
 
@@ -252,7 +253,9 @@ class TestMain(unittest.TestCase):
 
     @patch("src.main.common.show_error")
     @patch("src.main.append_output")
-    def test_get_secrets_invalid_output_id_with_newline(self, mock_append, mock_show_error):
+    def test_get_secrets_invalid_output_id_with_newline(
+        self, mock_append, mock_show_error
+    ):
         """Test get_secrets rejects output_id containing a newline (injection attempt)"""
         mock_show_error.side_effect = SystemExit(1)
         secret_obj = MagicMock()
@@ -275,7 +278,9 @@ class TestMain(unittest.TestCase):
 
     @patch("src.main.common.show_error")
     @patch("src.main.append_output")
-    def test_get_secrets_invalid_output_id_trailing_newline(self, mock_append, mock_show_error):
+    def test_get_secrets_invalid_output_id_trailing_newline(
+        self, mock_append, mock_show_error
+    ):
         """Test get_secrets rejects output_id with a trailing newline (regex $ bypass)"""
         mock_show_error.side_effect = SystemExit(1)
         secret_obj = MagicMock()
@@ -298,7 +303,9 @@ class TestMain(unittest.TestCase):
 
     @patch("src.main.common.show_error")
     @patch("src.main.append_output")
-    def test_get_secrets_invalid_output_id_special_chars(self, mock_append, mock_show_error):
+    def test_get_secrets_invalid_output_id_special_chars(
+        self, mock_append, mock_show_error
+    ):
         """Test get_secrets rejects output_id with disallowed special characters"""
         mock_show_error.side_effect = SystemExit(1)
         secret_obj = MagicMock()
@@ -318,7 +325,9 @@ class TestMain(unittest.TestCase):
 
     @patch("src.main.common.show_error")
     @patch("src.main.append_output")
-    def test_get_secrets_invalid_output_id_non_string(self, mock_append, mock_show_error):
+    def test_get_secrets_invalid_output_id_non_string(
+        self, mock_append, mock_show_error
+    ):
         """Test get_secrets rejects non-string output_id (e.g., null, number)"""
         mock_show_error.side_effect = SystemExit(1)
         secret_obj = MagicMock()
@@ -409,3 +418,143 @@ class TestMain(unittest.TestCase):
                 main.main()
 
             mock_show_error.assert_called_once()
+
+
+class TestParseVerifyCA(unittest.TestCase):
+    """
+    Tests for parse_verify_ca, which accepts a CA bundle path so a private or
+    internal CA can be trusted without disabling verification.
+    """
+
+    def test_true_when_unset(self):
+        """An unset VERIFY_CA keeps verification enabled."""
+        self.assertIs(main.parse_verify_ca(None), True)
+
+    def test_true_when_empty_or_whitespace(self):
+        """An empty or whitespace-only value keeps verification enabled."""
+        for value in ("", "   "):
+            with self.subTest(value=value):
+                self.assertIs(main.parse_verify_ca(value), True)
+
+    def test_all_enable_tokens_are_recognized(self):
+        """Every affirmative token enables verification."""
+        for token in ("true", "1", "yes", "on", "enable", "enabled", " TRUE "):
+            with self.subTest(token=token):
+                self.assertIs(main.parse_verify_ca(token), True)
+
+    def test_all_disable_tokens_are_recognized(self):
+        """Every negative token disables verification."""
+        for token in ("false", "0", "no", "off", "disable", "disabled", " FALSE "):
+            with self.subTest(token=token):
+                self.assertIs(main.parse_verify_ca(token), False)
+
+    def test_existing_bundle_file_is_passed_through(self):
+        """A path to an existing bundle file is returned as-is."""
+        with tempfile.NamedTemporaryFile(suffix=".crt") as bundle:
+            self.assertEqual(main.parse_verify_ca(bundle.name), bundle.name)
+
+    def test_existing_bundle_directory_is_passed_through(self):
+        """A path to an existing bundle directory is returned as-is."""
+        with tempfile.TemporaryDirectory() as bundle_dir:
+            self.assertEqual(main.parse_verify_ca(bundle_dir), bundle_dir)
+
+    def test_bundle_path_is_stripped(self):
+        """Surrounding whitespace is trimmed from a bundle path."""
+        with tempfile.NamedTemporaryFile(suffix=".crt") as bundle:
+            self.assertEqual(
+                main.parse_verify_ca(f"  {bundle.name}  "),
+                bundle.name,
+            )
+
+    def test_nonexistent_path_raises(self):
+        """
+        Fail closed: a mistyped bundle path must not silently fall back to
+        certifi, which would not trust the CA the caller asked for.
+        """
+        with self.assertRaises(EnvironmentError) as ctx:
+            main.parse_verify_ca("/no/such/ca-bundle.crt")
+
+        self.assertIn("VERIFY_CA", str(ctx.exception))
+
+    def test_unrecognized_value_raises(self):
+        """An unrecognized value is rejected instead of defaulting to True."""
+        with self.assertRaises(EnvironmentError):
+            main.parse_verify_ca("maybe")
+
+
+class TestConfigureCertificateVerification(unittest.TestCase):
+    """
+    Tests for configure_certificate_verification, which applies the setting to
+    the session and reports the trust store actually in effect.
+    """
+
+    def _verify_true_log_message(self, env_overrides):
+        """Return the message logged for verify_ca=True under env_overrides."""
+        session = requests.Session()
+        with patch.dict(os.environ, env_overrides, clear=True):
+            with patch("src.main.utils.print_log") as print_log:
+                main.configure_certificate_verification(session, True)
+        return print_log.call_args[0][1]
+
+    def test_session_verifies_against_bundle_path(self):
+        """A bundle path is assigned to the session itself."""
+        session = requests.Session()
+        with tempfile.NamedTemporaryFile(suffix=".crt") as bundle:
+            main.configure_certificate_verification(session, bundle.name)
+            self.assertEqual(session.verify, bundle.name)
+
+    def test_session_verify_defaults_to_true(self):
+        """verify_ca=True leaves the session verifying against the default store."""
+        session = requests.Session()
+        main.configure_certificate_verification(session, True)
+        self.assertIs(session.verify, True)
+
+    def test_session_verify_disabled(self):
+        """verify_ca=False disables verification on the session."""
+        session = requests.Session()
+        main.configure_certificate_verification(session, False)
+        self.assertFalse(session.verify)
+
+    def test_log_names_bundle_path(self):
+        """The bundle path in effect is logged."""
+        session = requests.Session()
+        with tempfile.NamedTemporaryFile(suffix=".crt") as bundle:
+            with patch("src.main.utils.print_log") as print_log:
+                main.configure_certificate_verification(session, bundle.name)
+
+            self.assertIn(bundle.name, print_log.call_args[0][1])
+
+    def test_log_names_requests_ca_bundle_override(self):
+        """
+        requests silently honors REQUESTS_CA_BUNDLE when verify is True, so the
+        log must name it instead of claiming certifi is in effect.
+        """
+        message = self._verify_true_log_message({"REQUESTS_CA_BUNDLE": "/tmp/req.crt"})
+
+        self.assertIn("REQUESTS_CA_BUNDLE", message)
+        self.assertIn("/tmp/req.crt", message)
+        self.assertNotIn(requests.adapters.DEFAULT_CA_BUNDLE_PATH, message)
+
+    def test_log_names_curl_ca_bundle_override(self):
+        """CURL_CA_BUNDLE is honored by requests too, so it is reported."""
+        message = self._verify_true_log_message({"CURL_CA_BUNDLE": "/tmp/curl.crt"})
+
+        self.assertIn("CURL_CA_BUNDLE", message)
+        self.assertIn("/tmp/curl.crt", message)
+
+    def test_requests_ca_bundle_takes_precedence_over_curl(self):
+        """REQUESTS_CA_BUNDLE wins when both overrides are set."""
+        message = self._verify_true_log_message(
+            {"REQUESTS_CA_BUNDLE": "/tmp/req.crt", "CURL_CA_BUNDLE": "/tmp/curl.crt"}
+        )
+
+        self.assertIn("/tmp/req.crt", message)
+        self.assertNotIn("/tmp/curl.crt", message)
+
+    def test_log_reports_certifi_when_no_override(self):
+        """Without an override the certifi bundle path is reported."""
+        message = self._verify_true_log_message({})
+
+        self.assertIn("certifi", message)
+        self.assertIn(requests.adapters.DEFAULT_CA_BUNDLE_PATH, message)
+        self.assertIn("VERIFY_CA", message)


### PR DESCRIPTION
## Purpose of the PR

- BIPS-34603: Allow `VERIFY_CA` to accept a path to a CA bundle (file or directory) in addition to `true`/`false`, so both actions can trust a private or internal CA without disabling certificate verification entirely.

## Linked JIRA issue(s)

- [BIPS-34603](https://beyondtrust.atlassian.net/browse/BIPS-34603)

## Summary of changes

- Added a `parse_verify_ca()` helper to `create_secret/src/main.py` and `get_secret/src/main.py` that resolves the `VERIFY_CA` env var: recognized truthy tokens (`true`, `1`, `yes`, `on`, `enable`, `enabled`) and falsy tokens (`false`, `0`, `no`, `off`, `disable`, `disabled`) are matched case-insensitively; any other value that resolves to an existing file or directory path is passed through as a CA bundle path; anything else raises `EnvironmentError` at startup. This is a fail-closed change from the previous behavior, where any value other than the literal string `"false"` silently fell back to `True` — a mistyped or missing bundle path now stops the action instead of quietly re-enabling default verification.
- Added a `configure_certificate_verification()` helper in both actions that assigns the resolved value to the `requests.Session.verify` attribute and logs (at `INFO`) which trust store is actually in effect: the CA bundle path, `certifi`'s bundled roots, or an override via `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` (with `REQUESTS_CA_BUNDLE` taking precedence, matching `requests`' own behavior).
- `VERIFY_CA` module-level parsing moved from an inline `env.get(...).lower() != "false"` expression to a call to `parse_verify_ca()` wrapped in `try`/`except EnvironmentError`, reporting the error via `common.show_error()`.
- Documented in the README that `true` verifies against `certifi`'s bundled roots, not the operating system trust store, so certificates trusted via `update-ca-trust`/`update-ca-certificates` on the host are not automatically trusted inside the container. Added a new "TLS certificate verification (`VERIFY_CA`)" section covering the accepted value table, how to supply a bundle at an in-container path (the workspace is mounted at `/github/workspace`), writing a bundle from a secret in a preceding step, and the `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` alternative.
- Updated the `verify_ca` input description in both `create_secret/action.yml` and `get_secret/action.yml` to mention the CA bundle path option and the certifi-vs-OS-trust-store distinction.
- Added unit tests in both `tests/unit/test_main.py` suites covering `parse_verify_ca()` (unset/empty values, all enable/disable tokens, existing file/directory bundle paths, whitespace stripping, nonexistent paths, and unrecognized values) and `configure_certificate_verification()` (session.verify assignment for bool/path values, and the logged trust-store message under no override, `REQUESTS_CA_BUNDLE`, and `CURL_CA_BUNDLE`, including override precedence).

## Checklist

### Release

- [ ] Priority release required due to hotfix / Escalation / Critical bug
- [x] Priority release not required (can be released later with other stories or bug fixes)

### Testing

- [x] dev
- [ ] automation (required for feature branch merges and significant changes)
- [ ] manual (required for feature branch merges and significant changes)

### Automation

- [ ] no changes are required
- [x] existing tests have been updated
- [x] new tests have been added
- [ ] further changes are required by the automation team


[BIPS-34603]: https://beyondtrust.atlassian.net/browse/BIPS-34603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ